### PR TITLE
Fix passing include_rc to docker 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
       - name: Get supported versions of Singlestore
         id: get_versions
         uses: singlestore-labs/singlestore-supported-versions@main
+        with:
+          include_rc: "true"
       # Use the output from the `get_versions` step
       - name: Print versions
         run: echo "versions ${{ steps.get_versions.outputs.versions }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get supported versions of Singlestore
         id: get_versions
-        uses: singlestore-labs/singlestore-supported-versions@main
+        uses: singlestore-labs/singlestore-supported-versions@pavlo-test
         with:
           include_rc: "true"
       # Use the output from the `get_versions` step

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         id: get_versions
         uses: singlestore-labs/singlestore-supported-versions@pavlo-test
         with:
-          include_rc: "true"
+          include_rc: true
       # Use the output from the `get_versions` step
       - name: Print versions
         run: echo "versions ${{ steps.get_versions.outputs.versions }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get supported versions of Singlestore
         id: get_versions
-        uses: singlestore-labs/singlestore-supported-versions@pavlo-test
+        uses: singlestore-labs/singlestore-supported-versions@main
         with:
           include_rc: true
       # Use the output from the `get_versions` step

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 # Install necessary dependencies
 RUN pip install requests beautifulsoup4

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ jobs:
       - name: Get supported versions of Singlestore
         id: get_versions
         uses: singlestore-labs/singlestore-supported-versions@main
+        # set include_rc to True if you want to include release candidates to the list 
+        with:
+          include_rc: true
 
   test:
     needs: fetch-s2-versions

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,4 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - python
-    - /action/singlestore_supported_versions.py
     - ${{ inputs.include_rc }}

--- a/singlestore_supported_versions.py
+++ b/singlestore_supported_versions.py
@@ -1,12 +1,13 @@
-import json
-import urllib.request
-from datetime import datetime
-import sys
 from bs4 import BeautifulSoup
+from datetime import datetime
+import json
 import os
+import sys
+import urllib.request
 
 SINGLESTORE_EOL_PAGE_LINK = "https://docs.singlestore.com/db/latest/support/singlestore-software-end-of-life-eol-policy/"
 RC_VERSIONS_LINK = "https://release.memsql.com/rc/index/singlestoredbserver/latest.json"
+
 
 def format_one_decimal(version):
     parts = version.split('.')
@@ -31,6 +32,7 @@ def get_table(html):
         data.append(values)
 
     return data
+
 
 def get_rc_versions():
     try:
@@ -68,12 +70,10 @@ if __name__ == "__main__":
     eol_page_html = get_page_html(SINGLESTORE_EOL_PAGE_LINK)
     eol_table = get_table(eol_page_html)
     supported_versions = get_supported_versions(eol_table)
-    print(f"included rc: {include_rc}")
     if include_rc:
         rc_versions = get_rc_versions()
         # Add RC versions not already in supported_versions
         supported_versions += [v for v in rc_versions if v not in supported_versions]
-    supported_versions += [str(include_rc)]
     # Write output to the GITHUB_OUTPUT file for GitHub Actions (replacement
     # for deprecated ::set-output).
     output_value = json.dumps(supported_versions)

--- a/singlestore_supported_versions.py
+++ b/singlestore_supported_versions.py
@@ -64,4 +64,5 @@ if __name__ == "__main__":
         rc_versions = get_rc_versions()
         # Add RC versions not already in supported_versions
         supported_versions += [v for v in rc_versions if v not in supported_versions]
+    supported_versions += [str(include_rc)]
     print(f"::set-output name=versions::{json.dumps(supported_versions)}")

--- a/singlestore_supported_versions.py
+++ b/singlestore_supported_versions.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         arg_val = sys.argv[1]
     elif "INPUT_INCLUDE_RC" in os.environ:
         arg_val = os.environ.get("INPUT_INCLUDE_RC")
-    if arg_val:
+    if arg_val is not None:
         include_rc = str(arg_val).lower() == "true"
 
     eol_page_html = get_page_html(SINGLESTORE_EOL_PAGE_LINK)

--- a/singlestore_supported_versions.py
+++ b/singlestore_supported_versions.py
@@ -59,6 +59,7 @@ if __name__ == "__main__":
     eol_page_html = get_page_html(SINGLESTORE_EOL_PAGE_LINK)
     eol_table = get_table(eol_page_html)
     supported_versions = get_supported_versions(eol_table)
+    print(f"included rc: {include_rc}")
     if include_rc:
         rc_versions = get_rc_versions()
         # Add RC versions not already in supported_versions


### PR DESCRIPTION
singlestore_supported_versions.py has been supplied both as an entrypoint and argument to the dockerfile, so include_rc was not set correctly. Also use `GITHUB_OUTPUT` instead of `set-output` to get rid of the deprecation warning.